### PR TITLE
Custom handlers and query params

### DIFF
--- a/router/query.go
+++ b/router/query.go
@@ -1,0 +1,23 @@
+package router
+
+import "fmt"
+
+type QueryParam struct {
+	Name     string
+	Regex    *string
+	Required bool
+}
+
+func buildQuery(qs []QueryParam) (result []string) {
+	for _, q := range qs {
+		result = append(result, q.Name)
+
+		if q.Regex != nil {
+			result = append(result, fmt.Sprintf("{%s:%s}", q.Name, *q.Regex))
+		} else {
+			result = append(result, fmt.Sprintf("{%s}", q.Name))
+		}
+	}
+
+	return
+}

--- a/router/response.go
+++ b/router/response.go
@@ -47,6 +47,8 @@ func sendError(w http.ResponseWriter, errToSend error) {
 		httpCode = apiException.StatusCode
 	}
 
+	w.Header().Set(contentType, "application/json")
+
 	w.WriteHeader(httpCode)
 	w.Write(response)
 }

--- a/router/router-builder.go
+++ b/router/router-builder.go
@@ -1,34 +1,53 @@
 package router
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
 )
 
+type dataType string
+
+const (
+	DataTypeJSON dataType = "json"
+	DataTypeFile dataType = "file"
+	contentType           = "Content-Type"
+)
+
+type DataHandler func(data interface{}, w http.ResponseWriter, successCode int) error
+
 type RouteParams struct {
-	body        []byte
-	PathParams  map[string]string
-	QueryParams map[string]string
+	body   []byte
+	Params map[string]string
 }
 
 func (p RouteParams) PopulateBody(target interface{}) error {
 	return json.Unmarshal(p.body, &target)
 }
 
+var dataTypeHandlers = map[dataType]DataHandler{
+	DataTypeJSON: jsonHandler,
+	DataTypeFile: fileHandler,
+}
+
 type RouteHandler func(request *http.Request, p RouteParams) (interface{}, error)
 
 type RouteBuilder struct {
-	path       string
-	handler    RouteHandler
-	methods    []string
-	returnCode int
-	apiVersion string
+	path        string
+	handler     RouteHandler
+	methods     []string
+	returnCode  int
+	apiVersion  string
+	dataType    *dataType
+	queryParams []QueryParam
 }
 
 func (b RouteBuilder) SetApiVersion(v string) RouteBuilder {
@@ -54,8 +73,20 @@ func (b RouteBuilder) SetReturnCode(code int) RouteBuilder {
 	return b
 }
 
+func (b RouteBuilder) AddQueryParam(q QueryParam) RouteBuilder {
+	b.queryParams = append(b.queryParams, q)
+
+	return b
+}
+
 func (b RouteBuilder) SetPath(uri string) RouteBuilder {
 	b.path = uri
+
+	return b
+}
+
+func (b RouteBuilder) SetDataType(t dataType) RouteBuilder {
+	b.dataType = &t
 
 	return b
 }
@@ -93,7 +124,7 @@ func (b RouteBuilder) Build(router *mux.Router) {
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		responseBody, err := (func() (i interface{}, err error) {
-			p := RouteParams{PathParams: mux.Vars(r)}
+			p := RouteParams{Params: mux.Vars(r)}
 
 			if r.Body != nil {
 				bBody, err := ioutil.ReadAll(r.Body)
@@ -113,7 +144,7 @@ func (b RouteBuilder) Build(router *mux.Router) {
 			return
 		}
 
-		preparedBody, err := prepareResponseBody(responseBody, nil)
+		dataHandler, err := getDataHandler(b)
 
 		if err != nil {
 			sendError(w, err)
@@ -121,14 +152,96 @@ func (b RouteBuilder) Build(router *mux.Router) {
 			return
 		}
 
-		w.WriteHeader(b.returnCode)
-		w.Write(preparedBody)
+		err = dataHandler(responseBody, w, b.returnCode)
+
+		if err != nil {
+			sendError(w, err)
+
+			return
+		}
 	}
 
 	path := fmt.Sprintf("/api/%s%s", b.apiVersion, b.path)
-	router.HandleFunc(path, handler).Methods(b.methods...)
+
+	hasRequiredQuery := false
+	hasQuery := len(b.queryParams) > 0
+
+	/* 	Due to the nature of the mux package we need to register a route twice if it has optional query params.
+	* 	Once for the route without any query params and once with the query so we can match in both scenarios.
+	* 	However, if the route has a required query param do not register the base route so the router will only match
+	*	if the param is provided
+	 */
+	if hasQuery {
+		for _, q := range b.queryParams {
+			if q.Required {
+				hasRequiredQuery = true
+				break
+			}
+		}
+	}
+
+	if hasQuery {
+		router.HandleFunc(path, handler).Methods(b.methods...).Queries(buildQuery(b.queryParams)...)
+
+		if !hasRequiredQuery {
+			// all params optional, therefore allow matching the route without query params
+			router.HandleFunc(path, handler).Methods(b.methods...)
+		}
+
+	} else {
+		// no query param, just register the route
+		router.HandleFunc(path, handler).Methods(b.methods...)
+	}
+
 }
 
 func NewV1RouteBuilder() RouteBuilder {
 	return RouteBuilder{apiVersion: "v1"}
+}
+
+func jsonHandler(data interface{}, w http.ResponseWriter, successCode int) error {
+	preparedBody, err := prepareResponseBody(data, nil)
+
+	if err != nil {
+		return err
+	}
+
+	w.Header().Set(contentType, "application/json")
+	w.WriteHeader(successCode)
+	w.Write(preparedBody)
+
+	return nil
+}
+
+func fileHandler(file interface{}, w http.ResponseWriter, successCode int) error {
+
+	if fileBytes, ok := file.([]byte); !ok {
+		return errors.New("handler did not return a file")
+	} else {
+		w.Header().Set("Expires", "0")
+		w.Header().Set("Content-Transfer-Encoding", "binary")
+		w.Header().Set("Content-Type", http.DetectContentType(fileBytes))
+		w.Header().Set("Content-Length", strconv.Itoa(int(len(fileBytes))))
+
+		w.WriteHeader(successCode)
+
+		reader := bytes.NewReader(fileBytes)
+		io.Copy(w, reader)
+	}
+
+	return nil
+}
+
+func getDataHandler(b RouteBuilder) (DataHandler, error) {
+	// unless specified treat all responses as JSON
+	if b.dataType == nil {
+		return jsonHandler, nil
+	}
+
+	if h, ok := dataTypeHandlers[*b.dataType]; ok {
+		return h, nil
+	} else {
+		return nil, fmt.Errorf("no data handler for responses of type %s", *b.dataType)
+	}
+
 }


### PR DESCRIPTION
* **Added** the option to provide a data type for the route. By default, if not provided the route will be treated as JSON
* **Added** the ability to provide query params