### PR TITLE
Update media + route builder fixes

### DIFF
--- a/messaging/changeset.go
+++ b/messaging/changeset.go
@@ -1,0 +1,24 @@
+package messaging
+
+const (
+	TopicUpdateMedia  = "mediapire.media.update"
+	TopicMediaUpdated = "mediapire.media.updated"
+)
+
+type UpdatedItem struct {
+	MediaId string `json:"mediaId"`
+	Content []byte `json:"content"`
+}
+
+type UpdateMediaMessage struct {
+	ChangesetId string                   `json:"changesetId"`
+	Items       map[string][]UpdatedItem `json:"items"`
+}
+
+type MediaUpdatedMessage struct {
+	Success       bool              `json:"success"`
+	FailureReason *string           `json:"failureReason"`
+	NodeId        string            `json:"nodeId"`
+	ChangesetId   string            `json:"transferId"`
+	IdChanges     map[string]string `json:"idChanges"`
+}

--- a/router/query.go
+++ b/router/query.go
@@ -1,23 +1,11 @@
 package router
 
-import "fmt"
-
 type QueryParam struct {
 	Name     string
 	Regex    *string
 	Required bool
 }
 
-func buildQuery(qs []QueryParam) (result []string) {
-	for _, q := range qs {
-		result = append(result, q.Name)
-
-		if q.Regex != nil {
-			result = append(result, fmt.Sprintf("{%s:%s}", q.Name, *q.Regex))
-		} else {
-			result = append(result, fmt.Sprintf("{%s}", q.Name))
-		}
-	}
-
-	return
+func (p QueryParam) String() string {
+	return p.Name
 }


### PR DESCRIPTION
* **Added** messaging topics + structs for media updating
* **Fixed** an issue where you could not provide 2 different routes that shared the same base path and different query parameters

```
Due to the nature of the mux package for a route that contains query parameters we attach a custom matcher.
The custom matcher creates a dummy router and will try to match the request to the base URL of the route. 
If we have a match we will parse the query parameters from the URL and set them as the mux Vars. However, 
if the amount of query parameters exceeds the expected amount from the route we will not match it. This allows to have multiple handlers for the same route but with different execution paths based on the query parameters. 
Another check is if one of the required query parameters is not present we mark the route has NOT matched.
 ```