### PR TITLE
Only read body if its content type JSON

### DIFF
--- a/router/route-builder.go
+++ b/router/route-builder.go
@@ -137,7 +137,7 @@ func (b RouteBuilder) Build(router *mux.Router) {
 		responseBody, err := (func() (i interface{}, err error) {
 			p := RouteParams{Params: mux.Vars(r)}
 
-			if r.Body != nil {
+			if r.Body != nil && r.Header.Get("Content-type") == "application/json" {
 				bBody, err := io.ReadAll(r.Body)
 				defer r.Body.Close()
 


### PR DESCRIPTION
* **Fixed** an issue where if a handler expected formData it would not be able to be parsed since the builder already reads the body before calling the handler.